### PR TITLE
Updates to UUID version 1.0

### DIFF
--- a/client-libraries/rust/modality-ingest-client/Cargo.toml
+++ b/client-libraries/rust/modality-ingest-client/Cargo.toml
@@ -14,4 +14,4 @@ thiserror = "1"
 tokio = { version = "1", features = ["net", "time", "io-util"] }
 tokio-native-tls = "0.3.0"
 url = { version = "2.1" }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
This is the current stable version, and is used for other dependencies, such as tracing.