### PR TITLE
Add AttrKeyEqValuePair env var substitution support

### DIFF
--- a/client-libraries/rust/modality-reflector-config/Cargo.toml
+++ b/client-libraries/rust/modality-reflector-config/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0", features=["derive"] }
 thiserror = "1.0.30"
 toml = "0.5"
 url = { version = "2.1" }
+regex = "1.6"
+lazy_static = "1.4"
 
 [dev-dependencies]
 tempfile = "3.1.0"


### PR DESCRIPTION
This commit adds environment variable substitution support in the `AttrKeyEqValuePair::from_str` implementation.

Supports the following substitution expressions:
* `${NAME}`
* `${NAME-default}`
* `${NAME:-default}`