### PR TITLE
Bump more package versions for crates.io

### DIFF
--- a/client-libraries/rust/Cargo.toml
+++ b/client-libraries/rust/Cargo.toml
@@ -17,12 +17,13 @@ members = [
 [workspace.dependencies]
 modality-api = { version = "0.2.0", path = "modality-api" }
 modality-auth-token = { version = "0.1", path = "modality-auth-token" }
-modality-ingest-client = { version = "0.2", path = "modality-ingest-client" }
-modality-ingest-protocol = { version = "0.1", path = "modality-ingest-protocol" }
+modality-ingest-client = { version = "0.3", path = "modality-ingest-client" }
+modality-ingest-protocol = { version = "0.2", path = "modality-ingest-protocol" }
 modality-mutator-protocol = { version = "0.2", path = "modality-mutator-protocol" }
-modality-mutator-server = { version = "0.1", path = "modality-mutator-server" }
+modality-mutator-server = { version = "0.2", path = "modality-mutator-server" }
 modality-mutation-plane = { version = "0.2", path = "modality-mutation-plane" }
-modality-plugin-utils = { version = "0.1", path = "modality-plugin-utils" }
+modality-mutation-plane-client = { version = "0.2", path = "modality-mutation-plane-client" }
+modality-plugin-utils = { version = "0.2", path = "modality-plugin-utils" }
 modality-reflector-config = { version = "0.3", path = "modality-reflector-config" }
 
 async-trait = "0.1.52"

--- a/client-libraries/rust/modality-ingest-client/Cargo.toml
+++ b/client-libraries/rust/modality-ingest-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modality-ingest-client"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/modality-sdk"

--- a/client-libraries/rust/modality-ingest-protocol/Cargo.toml
+++ b/client-libraries/rust/modality-ingest-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modality-ingest-protocol"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/modality-sdk"

--- a/client-libraries/rust/modality-mutation-plane-client/Cargo.toml
+++ b/client-libraries/rust/modality-mutation-plane-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modality-mutation-plane-client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/modality-sdk"

--- a/client-libraries/rust/modality-mutator-server/Cargo.toml
+++ b/client-libraries/rust/modality-mutator-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modality-mutator-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/modality-sdk"

--- a/client-libraries/rust/modality-plugin-utils/Cargo.toml
+++ b/client-libraries/rust/modality-plugin-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modality-plugin-utils"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/modality-sdk"


### PR DESCRIPTION
So they're SemVer compatible with the last package rev, from the crates.io convention perspective